### PR TITLE
Correctly forward type of parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.4 - 2024-05-19
+
+- Correctly forward type of `parse` function (with overloads) from `svelte/compiler`
+
 ## 0.1.3 - 2024-05-18
 
 - Support Svelte 5

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,4 @@
-type ParseFunc = typeof import('svelte/compiler').parse;
-type ParseOptions = Parameters<ParseFunc>[1];
-type ParseOutput = ReturnType<ParseFunc>;
-
 /**
  * Parse a Svelte template without parsing the script or style tags
  */
-export declare function parse(template: string, options?: ParseOptions): ParseOutput;
+export declare const parse: typeof import('svelte/compiler').parse;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const styleRegex = /<style(\s[^]*?)?(?:>([^]*?)<\/style>|\/>)/gim
 const contextModuleRegex = /context\s*=\s*["']module["']/i
 
 /** @type {import('./index').parse} */
-export function parse(template, options) {
+export const parse = function(template, options) {
   const originalTemplate = template
 
   // text nodes that will be injected into the ast. there maybe be multiple as the regex

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-parse-markup",
   "description": "Parse Svelte markup without parsing the script or style tags",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "author": "Bjorn Lu",
   "type": "module",


### PR DESCRIPTION
In https://github.com/bluwy/svelte-parse-markup/pull/2, I missed the overloads of `parse` (now that it outpus `LegacyRoot` or `Root` depending on the `modern` option ([see more here](https://github.com/sveltejs/svelte/blob/1784026843d2f7de6e449a5587da5dc30d467818/packages/svelte/src/compiler/index.js#L66-L102)). My apologies. This PR fixes just that.

Not sure what the most idiomatic syntax is for forwarding a complex function type like this. Feel free to leave comment if you know a better way. Thanks!

